### PR TITLE
Use Node.js 18 in CI/CD

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts'
+          node-version: 18
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: 'lts'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts'
+          node-version: 18
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: 'lts'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Chores:
- Updated the Node.js version used in our workflows from version '16' to the latest Long-Term Support (LTS) version. This ensures our development environment stays up-to-date with the most stable and secure version of Node.js, enhancing the reliability of our platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->